### PR TITLE
IN-88 Related to removing SOP & QAPP field references - setting core.…

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -56,7 +56,6 @@ module:
   entity_view_group_bypass: 0
   epa_core: 0
   epa_wysiwyg: 0
-  extends_feeds_cron: 0
   externalauth: 0
   feeds: 0
   feeds_ex: 0


### PR DESCRIPTION
…extension to uninstall extends_feeds_cron module, which queries SOP & QAPP feeds that are no longer available in configuration.