### PR TITLE
In 715

### DIFF
--- a/config/sync/block.block.maxteleworkalert.yml
+++ b/config/sync/block.block.maxteleworkalert.yml
@@ -1,0 +1,29 @@
+uuid: 7594eebf-17ae-4125-986e-da4153298f57
+langcode: en
+status: true
+dependencies:
+  config:
+    - fixed_block_content.fixed_block_content.max_telework_alert
+  module:
+    - fixed_block_content
+    - system
+  theme:
+    - epa_intranet
+id: maxteleworkalert
+theme: epa_intranet
+region: content
+weight: -4
+provider: null
+plugin: 'fixed_block_content:max_telework_alert'
+settings:
+  id: 'fixed_block_content:max_telework_alert'
+  label: 'Max Telework Alert'
+  provider: fixed_block_content
+  label_display: '0'
+  view_mode: ''
+visibility:
+  request_path:
+    id: request_path
+    pages: /telework
+    negate: false
+    context_mapping: {  }

--- a/config/sync/fixed_block_content.fixed_block_content.max_telework_alert.yml
+++ b/config/sync/fixed_block_content.fixed_block_content.max_telework_alert.yml
@@ -1,0 +1,14 @@
+uuid: a1cc1511-0d0a-4258-b717-ace113dff7ce
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.text
+  content:
+    - 'block_content:text:c79d3200-bd13-4e6f-a358-96a0576acb20'
+id: max_telework_alert
+title: 'Max Telework Alert'
+block_content_bundle: text
+default_content: '{"_links":{"self":{"href":"https:\/\/work.epa.gov\/block\/1221?_format=hal_json"},"type":{"href":"http:\/\/fixed_block_content.drupal.org\/rest\/type\/block_content\/text"}},"langcode":[{"value":"en","lang":"en"}],"type":[{"target_id":"text"}],"status":[{"value":true,"lang":"en"}],"info":[{"value":"Max Telework Alert","lang":"en"}],"reusable":[{"value":false}],"default_langcode":[{"value":true,"lang":"en"}],"revision_translation_affected":[{"value":true,"lang":"en"}],"metatag":[{"value":{"title":"| EPA@Work","canonical_url":"https:\/\/work.epa.gov\/block\/1221"}}],"body":[{"value":"\u003Cdiv class=\u0022usa-alert usa-alert--warning\u0022\u003E\r\n\u003Cdiv class=\u0022usa-alert__body\u0022\u003E\u003Cspan class=\u0022usa-alert__heading\u0022\u003EMaximum Telework\u003C\/span\u003E\r\n\u003Cp class=\u0022usa-alert__text\u0022\u003EAgency employees are operating under maximum telework flexibilities. As the \u003Ca data-entity-substitution=\u0022canonical\u0022 data-entity-type=\u0022node\u0022 data-entity-uuid=\u0022855dd0a1-0eac-4ff5-a45d-cdb8b339e825\u0022 href=\u0022\/node\/6136\u0022\u003EEPA 2022 Future of Work\u003C\/a\u003E plans are solidified, updated information will be made available.\u003C\/p\u003E\r\n\u003C\/div\u003E\r\n\u003C\/div\u003E\r\n","format":"simple_text","processed":"\u003Cdiv class=\u0022usa-alert usa-alert--warning\u0022\u003E\n\u003Cdiv class=\u0022usa-alert__body\u0022\u003E\u003Cspan class=\u0022usa-alert__heading\u0022\u003EMaximum Telework\u003C\/span\u003E\n\u003Cp class=\u0022usa-alert__text\u0022\u003EAgency employees are operating under maximum telework flexibilities. As the \u003Ca data-entity-substitution=\u0022canonical\u0022 data-entity-type=\u0022node\u0022 data-entity-uuid=\u0022855dd0a1-0eac-4ff5-a45d-cdb8b339e825\u0022 href=\u0022\/future-work\u0022\u003EEPA 2022 Future of Work\u003C\/a\u003E plans are solidified, updated information will be made available.\u003C\/p\u003E\n\u003C\/div\u003E\n\u003C\/div\u003E","summary":"","lang":"en"}]}'
+auto_export: 2
+protected: true


### PR DESCRIPTION
fixed block and it's content created. did not export config of other affected blocks for weight. can export that specific config locally after pulling down the post-merge dev branch.