### PR TITLE
Update simplesamlphp_auth.settings.yml

### DIFF
--- a/config/production/simplesamlphp_auth.settings.yml
+++ b/config/production/simplesamlphp_auth.settings.yml
@@ -13,7 +13,7 @@ role:
 register_users: true
 allow:
   set_drupal_pwd: false
-  default_login: false
+  default_login: true
   default_login_roles:
     authenticated: authenticated
   default_login_users: '1'
@@ -29,4 +29,3 @@ httponly: false
 _core:
   default_config_hash: BuLah1nwoT5oUjn6XIuKnXkjcvdt5tDIGQ6gAflOY0s
 login_link_show: false
-


### PR DESCRIPTION
If we don't allow local logins on PROD then users are logged out even while actively working in the CMS.