### PR TITLE
udpated for correct aria attributes

### DIFF
--- a/docroot/themes/custom/epa_intranet/preprocess/element/input__range.preprocess.inc
+++ b/docroot/themes/custom/epa_intranet/preprocess/element/input__range.preprocess.inc
@@ -12,4 +12,14 @@ function epa_intranet_preprocess_input__range(&$variables) {
   $variables['attributes']['class'][] = 'usa-range';
   $variables['attributes']['class'][] = 'usa-input';
   $variables['attributes']['class'][] = 'form-input';
+  if (isset($variables['attributes']['min'])) {
+    $variables['attributes']['aria-valuemin'] = $variables['attributes']['min'];
+  }
+  if (isset($variables['attributes']['max'])) {
+    $variables['attributes']['aria-valuemax'] = $variables['attributes']['max'];
+  }
+  if (isset($variables['attributes']['value'])) {
+    $variables['attributes']['aria-valuenow'] = $variables['attributes']['value'];
+  }
+
 }


### PR DESCRIPTION
Added some preprocessing to mimic that as an example, so range inputs will now have aria attributes matching their min/max/value attributes if they are provided: