### PR TITLE
Add patch to fix setSyncing() on null error.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -236,7 +236,8 @@
                 "2949017: There is no way to delete or update file entities of other users incl. user/1": "https://www.drupal.org/files/issues/2022-03-24/allow-user-with-delete-any-files-to-delete-in-bulk.patch",
                 "3035113: JSON API": "https://www.drupal.org/files/issues/2021-12-28/3035113-33.patch",
                 "2985882: Error: Call to a member function getLabel() after enabling layout_builder": "https://www.drupal.org/files/issues/2020-04-08/2985882-field-85.patch",
-                "923934: Block visibility has wrong logic": "https://www.drupal.org/files/issues/2021-10-01/923934-58.patch"
+                "923934: Block visibility has wrong logic": "https://www.drupal.org/files/issues/2021-10-01/923934-58.patch",
+                "3051453: Call to a member function setSyncing() on null when installing a module": "https://www.drupal.org/files/issues/2020-08-18/protect_against_invalid_ids_in_import_delete-3051453-10.patch"
             },
             "merge-plugin": {
                 "include": [


### PR DESCRIPTION
For some reason EPA needs but ORD does not.