### PR TITLE
Update group.role.form-outsider.yml

### DIFF
--- a/config/sync/group.role.form-outsider.yml
+++ b/config/sync/group.role.form-outsider.yml
@@ -24,6 +24,7 @@ permissions:
   - 'view group_node:article entity'
   - 'view group_node:blog_post entity'
   - 'view group_node:book entity'
+  - 'view group_node:form entity'
   - 'view group_node:landing_page entity'
   - 'view group_node:page entity'
   - 'view group_node:quiz entity'


### PR DESCRIPTION
Outsider role in the Forms group type did not have access to view published nodes. This was a hotfix on PROD.