### PR TITLE
Update views.view.content.yml

### DIFF
--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -781,17 +781,20 @@ display:
           group_content_plugins:
             'group_node:article': 'group_node:article'
             'group_node:blog_post': 'group_node:blog_post'
+            'group_node:book': 'group_node:book'
             'group_node:employee_profile': 'group_node:employee_profile'
+            'group_node:form': 'group_node:form'
             'group_node:landing_page': 'group_node:landing_page'
             'group_node:mass_mailer': 'group_node:mass_mailer'
             'group_node:page': 'group_node:page'
             'group_node:photos_of_the_week': 'group_node:photos_of_the_week'
+            'group_node:policy': 'group_node:policy'
+            'group_node:policy_delegation': 'group_node:policy_delegation'
             'group_node:quiz': 'group_node:quiz'
-            'group_node:staff_member': 'group_node:staff_member'
+            'group_node:transmittal_notce': 'group_node:transmittal_notce'
             'group_node:webform': 'group_node:webform'
             'group_node:event': '0'
-            'group_node:policy': '0'
-            'group_node:policy_delegation': '0'
+            'group_node:staff_member': '0'
         revision_uid:
           id: revision_uid
           table: node_revision


### PR DESCRIPTION
make sure the group name is showing for all group content. the admin/content screen was not displaying the group name for Book pages or any of the new policy content. I hotfixed on PROD and exported config. If it gets lost - nbd as only admins currently use that screen. Thought it was a good fix.