### PR TITLE
Update views.view.policy_definitions.yml

### DIFF
--- a/config/sync/views.view.policy_definitions.yml
+++ b/config/sync/views.view.policy_definitions.yml
@@ -1,6 +1,6 @@
 uuid: 5e866353-b54b-40ce-8d37-7485b36e63f2
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - taxonomy.vocabulary.policy_definitions
@@ -348,10 +348,10 @@ display:
         filter_groups: false
       display_description: ''
       display_extenders: {  }
-      path: policy/definitions/export
+      path: agency-directives/definitions/export
       filename: policy-definitions.csv
       automatic_download: false
-      store_in_public_file_directory: null
+      store_in_public_file_directory: false
       custom_redirect_path: false
       redirect_to_display: none
       include_query_params: false
@@ -536,7 +536,7 @@ display:
     display_options:
       display_description: ''
       display_extenders: {  }
-      path: policy/definitions
+      path: agency-directives/definitions
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
We have more than one content type using the Policy Definitions vocabulary – yet I did not see a ticket for enabling and updating the existing Policy Definitions vocabulary.

The help text on those fields reference [/policy/definitions].  I created a redirect to /agency-directives/definitions.

The Policy Definitions view is on EPA@Work but is disabled. The view:
•	was enabled
•	page path was updated to /agency-directives/definitions
•	The data export path updated to agency-directives/definitions/export