### PR TITLE
Update field.field.node.staff_member.field_official_portrait_link.yml

### DIFF
--- a/config/sync/field.field.node.staff_member.field_official_portrait_link.yml
+++ b/config/sync/field.field.node.staff_member.field_official_portrait_link.yml
@@ -15,12 +15,7 @@ label: 'Official Portrait Link'
 description: 'Enter the link where the official portrait is stored. Enter "Download Portrait" in the <em>Link text</em> field.'
 required: false
 translatable: false
-default_value:
-  -
-    attributes: {  }
-    uri: 'https://www.flicr.com/gp/usepagov/'
-    title: 'Download Portrait'
-    options: {  }
+default_value: {  }
 default_value_callback: ''
 settings:
   title: 2


### PR DESCRIPTION
Staff member nodes had default text and link for the Official Portrait fields. The default data is causing more wrong data than accurate. The help text is clear about how to fill out those fields, so I removed the default text.