### PR TITLE
Uninstall stage file proxy module

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -189,7 +189,7 @@ module:
   slick_ui: 0
   smart_date: 0
   smart_date_recur: 0
-  stage_file_proxy: 0
+  stage_file_proxy: 1
   syslog: 0
   system: 0
   tablefield: 0


### PR DESCRIPTION
This module was installed a long time ago and has never really been used since I came on. It was causing the scan to blow up so I am uninstalling it.