### PR TITLE
Enable ckeditor5 embedded content by default. It is required even if …

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -28,6 +28,7 @@ module:
   bulk_update_fields: 0
   ckeditor: 0
   ckeditor5: 0
+  ckeditor5_embedded_content: 0
   ckeditor_iframe: 0
   ckeditor_liststyle: 0
   ckeditor_templates: 0


### PR DESCRIPTION
…we don't want to use the button.