### PR TITLE
Install Term Merge and Term Reference Change

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -149,6 +149,8 @@
         "drupal/tablefield": "2.4",
         "drupal/taxonomy_manager": "2.0.10",
         "drupal/taxonomy_term_depth": "2.x-dev@dev",
+        "drupal/term_merge": "2.0-beta6",
+        "drupal/term_reference_change": "2.0-beta3",        
         "drupal/token": "1.15",
         "drupal/transliterate_filenames": "^1.5",
         "drupal/twig_field_value": "2.0.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b89f0bcdccdfa2c4373082ea135dd10",
+    "content-hash": "d47e5e8575d4ec5c262d7f5a943e4702",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -202,6 +202,8 @@ module:
   taxonomy_manager: 0
   taxonomy_term_depth: 0
   telephone: 0
+  term_merge: 0
+  term_reference_change: 0
   text: 0
   token: 0
   toolbar: 0


### PR DESCRIPTION
There is a defect in the latest Taxonomy Manager module. Installing Term Merge and Term Reference Change (both required/sub-modules? by this version) to see if this clears up the issue. Otherwise may try uninstalling everything and starting over.