### PR TITLE
Install Simple Menu Permissions module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -153,6 +153,7 @@
         "drupal/seven": "^1.0",
         "drupal/shs": "2.0",
         "drupal/simple_gmap": "3.1",
+        "drupal/simple_menu_permissions": "3.0",
         "drupal/simplesamlphp_auth": "^4.0",
         "drupal/single_content_sync": "^1.3.9",
         "drupal/slick": "^2.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9fa26f7f1b391578fa4edc395ad3ca73",
+    "content-hash": "d99bc02c377c574325a7ceffad741fd0",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -11433,6 +11433,50 @@
             "homepage": "https://www.drupal.org/project/simple_gmap",
             "support": {
                 "source": "https://git.drupalcode.org/project/simple_gmap"
+            }
+        },
+        {
+            "name": "drupal/simple_menu_permissions",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/simple_menu_permissions.git",
+                "reference": "3.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/simple_menu_permissions-3.0.0.zip",
+                "reference": "3.0.0",
+                "shasum": "1f2c1fb6454baf59789cd901f1b56b6786dad922"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9 || ^10 || ^11"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "3.0.0",
+                    "datestamp": "1728856305",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "ewout goosmann",
+                    "homepage": "https://www.drupal.org/user/3138239"
+                }
+            ],
+            "description": "Defines permissions for each menu. Such as the edit and delete permission. Also defines a permission to create new menus.",
+            "homepage": "https://www.drupal.org/project/simple_menu_permissions",
+            "support": {
+                "source": "https://git.drupalcode.org/project/simple_menu_permissions"
             }
         },
         {


### PR DESCRIPTION
Having an issue with Groupmenu admin permissions. This module might help with a workaround solution. Adding to composer now then will install in the UI. If it helps out I will then add to the core.extension.yml file to auto-install.