### PR TITLE
in-3057 Calendar -  Dynamic lists are not showing times for single events

### DIFF
--- a/docroot/modules/custom/fullcalendar_combined_tooltip/css/tooltip-style.css
+++ b/docroot/modules/custom/fullcalendar_combined_tooltip/css/tooltip-style.css
@@ -43,3 +43,35 @@
   overflow: visible !important;
   position: relative; /* Needed for overflow fix */
 }
+
+.fc-daygrid-event-dot {
+  display: none !important;
+}
+
+/* Force background color for FullCalendar events */
+.fc-event {
+  background-color: #3a87ad !important;
+  border-color: #3a87ad !important;
+  color: #fff !important;
+  padding-left: 5px !important;
+  overflow: hidden;
+}
+
+
+/* Bold only the time */
+.fc-event-time {
+  font-weight: bold;
+  display: block;
+  line-height: 1.2;
+  margin-bottom: 2px;
+   min-width: auto !important; /* Force proper text wrapping */
+  white-space: nowrap;
+}
+
+/* Remove bold from title */
+.fc-event-title {
+  font-weight: normal !important;
+  display: block;
+  line-height: 1.2;
+ min-width: auto !important; /* Prevent forced overflow */
+}

--- a/docroot/modules/custom/fullcalendar_combined_tooltip/fullcalendar_combined_tooltip.libraries.yml
+++ b/docroot/modules/custom/fullcalendar_combined_tooltip/fullcalendar_combined_tooltip.libraries.yml
@@ -1,9 +1,11 @@
+
 calendar_assets:
   js:
     https://cdn.jsdelivr.net/npm/fullcalendar@6.1.9/index.global.min.js: { type: external }
     https://unpkg.com/@popperjs/core@2: { type: external }
     https://unpkg.com/tippy.js@6/dist/tippy-bundle.umd.min.js: { type: external }
     js/calendar-init.js: {}
+    js/fix-time-format.js: {}
   css:
     theme:
       https://cdn.jsdelivr.net/npm/fullcalendar@6.1.9/main.min.css: { type: external }

--- a/docroot/modules/custom/fullcalendar_combined_tooltip/fullcalendar_combined_tooltip.module
+++ b/docroot/modules/custom/fullcalendar_combined_tooltip/fullcalendar_combined_tooltip.module
@@ -1,6 +1,8 @@
 <?php
 
 use Drupal\node\NodeInterface;
+use Drupal\views\ViewExecutable;
+use Drupal\Core\Routing\RouteMatchInterface;
 
 /**
  * Implements hook_fullcalendar_event_alter().
@@ -19,11 +21,42 @@ function fullcalendar_combined_tooltip_fullcalendar_event_alter(array &$event, a
  */
 function fullcalendar_combined_tooltip_fullcalendar_calendar_alter(array &$calendar, array $context) {
   $calendar['eventDidMount'] = 'function(info) {
+    // Format time
+    if (info.event.start) {
+      const timeEl = info.el.querySelector(".fc-event-time");
+      if (timeEl) {
+        timeEl.textContent = info.event.start.toLocaleTimeString([], {
+          hour: "numeric",
+          minute: "2-digit"
+        });
+      }
+    }
+
+    // Set description as data attribute
     if (info.event.extendedProps && info.event.extendedProps.description) {
       info.el.setAttribute("data-description", info.event.extendedProps.description);
     }
+
+    // 🔵 Set background color
+    info.el.style.backgroundColor = "#3a87ad";
+    info.el.style.borderColor = "#3a87ad";
+    info.el.style.color = "white";
   }';
 }
+
+/**
+ * Implements hook_page_attachments().
+ */
+ /*
+function fullcalendar_combined_tooltip_page_attachments(array &$attachments) {
+  $current_path = \Drupal::service('path.current')->getPath();
+
+  // ✅ Replace with your actual calendar view page path.
+  if (str_starts_with($current_path, '/calendar')) {
+    $attachments['#attached']['library'][] = 'fullcalendar_combined_tooltip/calendar_assets';
+  }
+}
+*/
 
 /**
  * Implements hook_page_attachments().

--- a/docroot/modules/custom/fullcalendar_combined_tooltip/js/calendar-init.js
+++ b/docroot/modules/custom/fullcalendar_combined_tooltip/js/calendar-init.js
@@ -1,7 +1,7 @@
 (function ($, Drupal) {
   Drupal.behaviors.fullcalendarTooltip = {
     attach: function (context, settings) {
-      console.log('✅ fullcalendarTooltip behavior attached');
+      console.log('✅ fullcalendarTooltip behavior attached -- Testing #2');
 
       // Load the description data from JSON feed
       function attachTooltipsFromFeed() {

--- a/docroot/modules/custom/fullcalendar_combined_tooltip/js/fix-time-format.js
+++ b/docroot/modules/custom/fullcalendar_combined_tooltip/js/fix-time-format.js
@@ -1,0 +1,36 @@
+// ✅ Add this at the very top -Testing fix-time-format file loading or not
+//console.log('🎯 fix-time-format.js is loading... ');
+
+(function ($, Drupal) {
+  Drupal.behaviors.fixTimeFormat = {
+    attach: function (context, settings) {
+      console.log('🎯 fix-time-format.js is running...');
+
+      // Delay to wait for FullCalendar to render
+      let retryCount = 0;
+      const interval = setInterval(() => {
+        const $times = $('.fc-event-time', context).not('.fc-time-fixed');
+        if ($times.length > 0 || retryCount >= 10) {
+          clearInterval(interval);
+          $times.each(function () {
+            const $el = $(this);
+            const original = $el.text().trim();
+            console.log('🔍 Found event time:', original);
+            const match = original.match(/^(\d{1,2})(a|p)$/i);
+            if (match) {
+              const hour = parseInt(match[1]);
+              const suffix = match[2].toLowerCase() === 'a' ? 'am' : 'pm';
+              const formatted = `${hour}:00 ${suffix}`;
+              console.log(`⏰ Converting "${original}" → "${formatted}"`);
+              $el.text(formatted);
+              $el.addClass('fc-time-fixed');
+            }
+          });
+        } else {
+          retryCount++;
+        }
+      }, 500);
+    }
+  };
+})(jQuery, Drupal);
+


### PR DESCRIPTION
 Adding the fix-time-format.js file to convert the single event time, adding background color, and format the event title.