### PR TITLE
Make GCM perm on Dev and tweak the metatag fix that popped on node 1

### DIFF
--- a/config/sync/group.content_type.group_content_type_7cdc1b0a6ed7b.yml
+++ b/config/sync/group.content_type.group_content_type_7cdc1b0a6ed7b.yml
@@ -1,0 +1,21 @@
+uuid: 7f2dcad3-57a5-4224-b626-75c71ec464e1
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.web_area
+    - group_content_menu.group_content_menu_type.web_area_menu
+  module:
+    - group_content_menu
+id: group_content_type_7cdc1b0a6ed7b
+label: 'Web Area: Group menu (Web Area Menu)'
+description: 'Adds <em class="placeholder">Web Area Menu</em> menu items to groups.'
+group_type: web_area
+content_plugin: 'group_content_menu:web_area_menu'
+plugin_config:
+  group_cardinality: 1
+  entity_cardinality: 1
+  use_creation_wizard: false
+  auto_create_group_menu: true
+  auto_create_home_link: false
+  auto_create_home_link_title: Home

--- a/config/sync/group_content_menu.group_content_menu_type.web_area_menu.yml
+++ b/config/sync/group_content_menu.group_content_menu_type.web_area_menu.yml
@@ -1,0 +1,6 @@
+uuid: c37d026b-9bbd-433b-a9bb-e4235001ec19
+langcode: en
+status: true
+dependencies: {  }
+id: web_area_menu
+label: 'Web Area Menu'

--- a/docroot/themes/custom/epa_intranet_2/epa_intranet_2.theme
+++ b/docroot/themes/custom/epa_intranet_2/epa_intranet_2.theme
@@ -294,7 +294,9 @@ function epa_intranet_2_preprocess_page(&$variables)
       $node_web_area = '';
       $node_content_type = $node->type->entity->label();
       $group_labels = '';
-      $group_labels = get_group_labels_by_node_id($node->id());
+      if ($node->id() != 1) {
+        $group_labels = get_group_labels_by_node_id($node->id());
+      }
 
       if ($group_labels != null) {
         $node_web_area = $group_labels;


### PR DESCRIPTION
1.  Making a couple config files match webcms permanent
2. Found a hard error on the homepage that was related to the fix I made to the Metatag. Not sure why it popped up now but might be related to something that I updated locally when I ran Composer Update. I went aaead and checked for node 1 now in the epa_intranet_2.theme and included it here.