### PR TITLE
Added a new function to the EPA Core module from webcms

### DIFF
--- a/docroot/modules/custom/epa_core/epa_core.module
+++ b/docroot/modules/custom/epa_core/epa_core.module
@@ -26,3 +26,13 @@ function epa_core_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_
   }
   $form['#attached']['library'][] = 'epa_core/admin-forms';
 }
+/**
+ * Implements hook_module_implements_alter().
+ */
+function epa_core_module_implements_alter(&$implementations, $hook) {
+  // Prevent group_content_menu module's form alter from happening.
+  // This prevents the menu settings from being displayed
+  if ($hook === 'form_alter' && isset($implementations['group_content_menu'])) {
+    unset($implementations['group_content_menu']);
+  }
+}


### PR DESCRIPTION
This function was copied over from webcms since it directly relates to the feature we are working on. It "prevents the menu settings from being displayed". Not sure if this is going to change anything but it is worth a test since it alters the group content module.