### PR TITLE
INTRASUP-125: Prevent fatal error when embedded media is missing

### DIFF
--- a/docroot/modules/custom/media_inline_embed/src/Form/EditorInlineMediaDialog.php
+++ b/docroot/modules/custom/media_inline_embed/src/Form/EditorInlineMediaDialog.php
@@ -62,6 +62,17 @@ class EditorInlineMediaDialog extends EditorMediaDialog {
 
     $media = $this->entityRepository->loadEntityByUuid('media', $media_embed_element['data-entity-uuid']);
 
+    // Guard against missing or deleted media entities. If the UUID in the
+    // embed element no longer corresponds to an existing media entity,
+    // return the form early with a user-facing notice to avoid a fatal
+    // TypeError in getMediaImageSourceFieldName().
+    if (!$media instanceof \Drupal\media\MediaInterface) {
+      $form['missing_media_notice'] = [
+        '#markup' => $this->t('The embedded media could not be found. It may have been deleted. Please remove it from the editor.'),
+      ];
+      return $form;
+    }
+
     if ($image_field_name = $this->getMediaImageSourceFieldName($media)) {
       // We'll want the alt text from the same language as the host.
       if (!empty($editor_object['hostEntityLangcode']) && $media->hasTranslation($editor_object['hostEntityLangcode'])) {


### PR DESCRIPTION
Guard against missing or deleted media entities. If the UUID in the embed element no longer corresponds to an existing media entity, return the form early with a user-facing notice to avoid a fatal TypeError in getMediaImageSourceFieldName().

https://jira.epa.gov/browse/INTRASUP-125

