### PR TITLE
Refines CI/CD pipeline for reliability and efficiency

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,13 @@ build:image:
     entrypoint: [""]
   script:
     - mkdir -p /kaniko/.docker
+    # Registry auth so Kaniko can pull the PHP base image and push the result.
     - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json
+    # Build + push. The caching flags let unchanged layers (notably the Composer
+    # dependency layer) restore from the registry cache instead of rebuilding:
+    #   --build-arg PHP_BASE_TAG : pin the PHP base tag (set a CI var to override 'latest')
+    #   --cache/--cache-repo/--cache-ttl : enable + locate the layer cache (kept 14 days)
+    #   --cache-copy-layers : also cache COPY layers (e.g. the composer.json/lock copy)
     - |-
       /kaniko/executor \
         --context $CI_PROJECT_DIR \
@@ -45,6 +51,11 @@ build:image:
         --cache-copy-layers=true \
         --destination $CI_REGISTRY_IMAGE/intranetcms-build:$CI_COMMIT_SHORT_SHA
 
+# ---------------------------------------------------------------------------
+# Prisma Scan - Prisma Cloud (twistcli) vulnerability scan of the built image.
+# `needs: build:image` runs it in PARALLEL with the deploy, and
+# `allow_failure: true` (below) means findings never block a deployment.
+# ---------------------------------------------------------------------------
 Prisma Scan:
   stage: scan
   needs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,7 +39,16 @@ Build IntranetCMS Image:
   script:
     - mkdir -p /kaniko/.docker
     - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json
-    - /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/docker/Dockerfile --destination $CI_REGISTRY_IMAGE/intranetcms-build:$CI_COMMIT_SHORT_SHA
+    - |-
+      /kaniko/executor \
+        --context $CI_PROJECT_DIR \
+        --dockerfile $CI_PROJECT_DIR/docker/Dockerfile \
+        --build-arg PHP_BASE_TAG=${PHP_BASE_TAG:-latest} \
+        --cache=true \
+        --cache-repo=$CI_REGISTRY_IMAGE/cache \
+        --cache-ttl=336h \
+        --cache-copy-layers=true \
+        --destination $CI_REGISTRY_IMAGE/intranetcms-build:$CI_COMMIT_SHORT_SHA
 
 Prisma Scan:
   stage: prisma scan

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,13 +1,8 @@
 stages:
-
   - build
-  - prisma scan
-  - Non-Production Dev Deployment
-  - Non-Production Stage Deployment
-  - Non-Production Dev10 Deployment
-  - Non-Production Stage Post Deploy
-  - Non-Production Dev Post Deploy
-  - Non-Production Dev10 Post Deploy
+  - scan
+  - deploy
+  - post-deploy
   - dast
 
 include:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ variables:
   DAST_SKIP_TARGET_CHECK: "true"
 
  
-Build IntranetCMS Image:
+build:image:
   stage: build
   rules:
     - if: '$CI_COMMIT_BRANCH == "dev-container" || $CI_COMMIT_BRANCH == "stage-container-1" || $CI_COMMIT_BRANCH == "dev-container-10"'
@@ -46,7 +46,11 @@ Build IntranetCMS Image:
         --destination $CI_REGISTRY_IMAGE/intranetcms-build:$CI_COMMIT_SHORT_SHA
 
 Prisma Scan:
-  stage: prisma scan
+  stage: scan
+  needs:
+    - "build:image"
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "dev-container" || $CI_COMMIT_BRANCH == "stage-container-1" || $CI_COMMIT_BRANCH == "dev-container-10"'
   tags:
     - twistcli
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,13 +124,52 @@ deploy:stage:
 
 
 
+# ---------------------------------------------------------------------------
+# .postdeploy - run post-deploy Drush as a Kubernetes Job and WAIT for it, so a
+# failed DB update / config import fails the pipeline. Previously this used
+# `kubectl create` on a bare Pod and returned immediately, hiding Drush errors.
+# The Drush Job itself (k8s/drush*.yml) toggles maintenance mode around updb/cim.
+# ---------------------------------------------------------------------------
 .postdeploy:
   stage: post-deploy
   image: dtzar/helm-kubectl
   script:
+    # Point kubectl at the GitLab-managed cluster agent for this environment.
     - kubectl config use-context $KUBE_CONTEXT
-    - apk add gettext
-    - envsubst < $MANIFEST | kubectl create -f - -n $NAMESPACE
+    - apk add --no-cache gettext
+    - |-
+      set -eu
+      # Create the Drush Job (generateName gives each run a unique name) and
+      # capture its resource name (e.g. "job.batch/drush-abc12") for polling.
+      JOB=$(envsubst < "$MANIFEST" | kubectl create -f - -n "$NAMESPACE" -o name)
+      JOB_NAME=${JOB##*/}
+      echo "Created $JOB in namespace $NAMESPACE"
+      # Bounded wait (the Job has activeDeadlineSeconds: 1800); fail loudly if Drush does not succeed.
+      deadline=$(( $(date +%s) + 1860 ))
+      # Poll the Job status until it succeeds, fails, or we pass the deadline.
+      while true; do
+        succeeded=$(kubectl get "$JOB" -n "$NAMESPACE" -o jsonpath='{.status.succeeded}' 2>/dev/null || true)
+        failed=$(kubectl get "$JOB" -n "$NAMESPACE" -o jsonpath='{.status.failed}' 2>/dev/null || true)
+        # Success: Drush finished cleanly; stop waiting.
+        if [ "$succeeded" = "1" ]; then
+          break
+        fi
+        if [ -n "$failed" ] && [ "$failed" != "0" ]; then
+          echo "Drush Job $JOB_NAME failed:"
+          kubectl logs "job/$JOB_NAME" -n "$NAMESPACE" --all-containers --tail=-1 || true
+          kubectl describe "$JOB" -n "$NAMESPACE" || true
+          exit 1
+        fi
+        if [ "$(date +%s)" -ge "$deadline" ]; then
+          echo "Timed out waiting for Drush Job $JOB_NAME."
+          kubectl logs "job/$JOB_NAME" -n "$NAMESPACE" --all-containers --tail=-1 || true
+          exit 1
+        fi
+        sleep 10
+      done
+      echo "Drush Job $JOB_NAME completed successfully:"
+      kubectl logs "job/$JOB_NAME" -n "$NAMESPACE" --all-containers --tail=-1 || true
+      kubectl delete "$JOB" -n "$NAMESPACE" --ignore-not-found
 
 postdeploy:stage:
   extends: .postdeploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,13 +1,30 @@
+# =============================================================================
+# IntraCMS GitLab CI/CD pipeline
+#
+# Ordering is driven by `needs:` (a DAG), NOT by stage order. On a push to a
+# *-container* branch:
+#
+#   build:image --+--> deploy:<env> --> postdeploy:<env>  (Drush updb/cim/cr)
+#                 +--> Prisma Scan                         (parallel, non-blocking)
+#
+# A deploy therefore starts as soon as the image is built, instead of waiting
+# for the security scan. Each branch only runs the jobs whose `rules:` match:
+#   dev-container     -> dev    (namespace cms-45-dev)
+#   dev-container-10  -> dev10  (namespace cms-45-next)
+#   stage-container-1 -> stage  (namespace cms-45-stage)
+# =============================================================================
 stages:
-  - build
-  - scan
-  - deploy
-  - post-deploy
-  - dast
+  - build        # Build the Drupal application image with Kaniko.
+  - scan         # Prisma Cloud vulnerability scan (non-blocking).
+  - deploy       # Apply the k8s manifests (Deployment/Service/Ingress).
+  - post-deploy  # Run Drush updb/cim/cr as a verified k8s Job.
+  - dast         # Manual dynamic security scan (ZAP) against stage.
 
 include:
   - template: DAST.gitlab-ci.yml
 
+# DAST (Dynamic Application Security Testing) settings consumed by the
+# GitLab-managed `dast` job pulled in via the DAST.gitlab-ci.yml include above.
 variables:
   DAST_WEBSITE: "https://stage.intranetcms-stage.aws.epa.gov/"
   DAST_AUTH_URL: "https://stage.intranetcms-stage.aws.epa.gov/user/login?destination=/node/1"
@@ -22,6 +39,11 @@ variables:
   DAST_SKIP_TARGET_CHECK: "true"
 
  
+# ---------------------------------------------------------------------------
+# build:image - build the Drupal application image with Kaniko and push it to
+# the registry as intranetcms-build:<short-sha>. Runs only on the three
+# container branches; always on the dev runner (stage images are built here too).
+# ---------------------------------------------------------------------------
 build:image:
   stage: build
   rules:
@@ -65,6 +87,7 @@ Prisma Scan:
   tags:
     - twistcli
   variables:
+    # No repo checkout needed - this job only pulls and scans the image.
     GIT_STRATEGY: none
   script:
     - 'export PRISMA_CI_TOKEN=$(curl -kH "Content-Type: application/json" -d "{\"username\":\"$PRISMA_CI_USERNAME\", \"password\":\"$PRISMA_CI_PASSWORD\"}" https://prismacloud.epa.gov/api/v32.01/authenticate | jq -r .token)'
@@ -78,14 +101,22 @@ Prisma Scan:
     - rm -rf $CI_PROJECT_DIR
 
 
+# ---------------------------------------------------------------------------
+# .deploy - reusable template for the three environment deploys. Each concrete
+# job below sets only its runner tag, kube-agent context, manifest, namespace,
+# and environment. `needs: build:image` means deploys do NOT wait for the scan.
+# ---------------------------------------------------------------------------
 .deploy:
   stage: deploy
   needs:
     - "build:image"
   image: dtzar/helm-kubectl
   script:
+    # Point kubectl at the GitLab-managed cluster agent for this environment.
     - kubectl config use-context $KUBE_CONTEXT
+    # `envsubst` (gettext) expands ${CI_*} placeholders inside the manifest.
     - apk add gettext
+    # Render the manifest and apply it to the environment's namespace.
     - envsubst < $MANIFEST | kubectl apply -f - -n $NAMESPACE
 
 deploy:dev:
@@ -233,6 +264,10 @@ postdeploy:dev10:
     kubernetes:
       namespace: cms-45-next
 
+# ---------------------------------------------------------------------------
+# dast - Dynamic Application Security Testing (ZAP) against stage. Manual only;
+# overrides the GitLab-managed job from the DAST.gitlab-ci.yml include above.
+# ---------------------------------------------------------------------------
 dast:
   tags:
     - intranetcms-stg-runner

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,11 +14,13 @@
 #   stage-container-1 -> stage  (namespace cms-45-stage)
 # =============================================================================
 stages:
-  - build        # Build the Drupal application image with Kaniko.
-  - scan         # Prisma Cloud vulnerability scan (non-blocking).
-  - deploy       # Apply the k8s manifests (Deployment/Service/Ingress).
-  - post-deploy  # Run Drush updb/cim/cr as a verified k8s Job.
-  - dast         # Manual dynamic security scan (ZAP) against stage.
+  - build             # Build the Drupal application image with Kaniko.
+  - scan              # Prisma Cloud vulnerability scan (non-blocking).
+  - deploy            # Apply the k8s manifests (Deployment/Service/Ingress).
+  - post-deploy       # Run Drush updb/cim/cr as a verified k8s Job.
+  - prod-deploy       # Manually promote the stage-validated image to production.
+  - prod-post-deploy  # Run the verified Drush Job in production.
+  - dast              # Manual dynamic security scan (ZAP) against stage.
 
 include:
   - template: DAST.gitlab-ci.yml
@@ -263,6 +265,60 @@ postdeploy:dev10:
     name: dev10
     kubernetes:
       namespace: cms-45-next
+
+# ===========================================================================
+# PRODUCTION PROMOTION (manual, image-promotion model)
+#
+# Prod is NOT built or deployed from its own branch. A successful stage run
+# (deploy:stage + its verified Drush) unlocks a manual deploy:prod that promotes
+# the EXACT SAME intranetcms-build:<sha> image stage validated - no rebuild, so
+# no drift. After stage passes the pipeline shows "blocked": that is the
+# ready-to-promote state; play deploy:prod to release to production.
+# ===========================================================================
+
+# deploy:prod - manual promotion. `needs: postdeploy:stage` means it only
+# becomes available once stage (including its Drush Job) has fully succeeded.
+deploy:prod:
+  extends: .deploy
+  stage: prod-deploy
+  needs:
+    - "postdeploy:stage"
+  rules:
+    # Promotion runs from the stage pipeline and requires a human to play it.
+    - if: '$CI_COMMIT_BRANCH == "stage-container-1"'
+      when: manual
+  tags:
+    - intranetcms-prod-runner
+  variables:
+    # TODO: confirm the prod agent's registered context name (GitLab > Operate >
+    # Kubernetes) and that the agent authorizes the IntraCMS project.
+    KUBE_CONTEXT: intranet-cms/intranetcms-k8s-resources:intranetcms-prod-k8s-agent
+    MANIFEST: k8s/intranetcms-prod.yml
+    NAMESPACE: cms-45-prod
+  environment:
+    name: prod
+    kubernetes:
+      namespace: cms-45-prod
+
+# postdeploy:prod - runs the verified Drush Job in prod right after deploy:prod
+# succeeds (reuses the hardened .postdeploy template + k8s/drush.yml).
+postdeploy:prod:
+  extends: .postdeploy
+  stage: prod-post-deploy
+  needs:
+    - "deploy:prod"
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "stage-container-1"'
+  tags:
+    - intranetcms-prod-runner
+  variables:
+    KUBE_CONTEXT: intranet-cms/intranetcms-k8s-resources:intranetcms-prod-k8s-agent
+    MANIFEST: k8s/drush.yml
+    NAMESPACE: cms-45-prod
+  environment:
+    name: prod
+    kubernetes:
+      namespace: cms-45-prod
 
 # ---------------------------------------------------------------------------
 # dast - Dynamic Application Security Testing (ZAP) against stage. Manual only;

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -67,107 +67,119 @@ Prisma Scan:
     - rm -rf $CI_PROJECT_DIR
 
 
-Development:
-  stage: Non-Production Dev Deployment
+.deploy:
+  stage: deploy
+  needs:
+    - "build:image"
+  image: dtzar/helm-kubectl
+  script:
+    - kubectl config use-context $KUBE_CONTEXT
+    - apk add gettext
+    - envsubst < $MANIFEST | kubectl apply -f - -n $NAMESPACE
+
+deploy:dev:
+  extends: .deploy
   rules:
     - if: '$CI_COMMIT_BRANCH == "dev-container"'
   tags:
     - intranetcms-dev-runner
-  image: dtzar/helm-kubectl
-  script:
-    - kubectl config use-context intranet-cms/intracms-infra-dev:intranetcms-dev-k8s-agent
-    - apk add gettext
-    - envsubst < k8s/intranetcms.yml | kubectl apply -f - -n cms-45-dev
+  variables:
+    KUBE_CONTEXT: intranet-cms/intracms-infra-dev:intranetcms-dev-k8s-agent
+    MANIFEST: k8s/intranetcms.yml
+    NAMESPACE: cms-45-dev
   environment:
     name: dev
-    url:
     kubernetes:
       namespace: cms-45-dev
 
-Development10:
-  stage: Non-Production Dev10 Deployment
+deploy:dev10:
+  extends: .deploy
   rules:
     - if: '$CI_COMMIT_BRANCH == "dev-container-10"'
   tags:
     - intranetcms-dev-runner
-  image: dtzar/helm-kubectl
-  script:
-    - kubectl config use-context intranet-cms/intracms-infra-dev:intranetcms-dev-k8s-agent
-    - apk add gettext
-    - envsubst < k8s/intranetcms-dev10.yml | kubectl apply -f - -n cms-45-next
+  variables:
+    KUBE_CONTEXT: intranet-cms/intracms-infra-dev:intranetcms-dev-k8s-agent
+    MANIFEST: k8s/intranetcms-dev10.yml
+    NAMESPACE: cms-45-next
   environment:
     name: dev10
-    url:
     kubernetes:
       namespace: cms-45-next
 
-Stage:
-  stage: Non-Production Stage Deployment
+deploy:stage:
+  extends: .deploy
   rules:
     - if: '$CI_COMMIT_BRANCH == "stage-container-1"'
   tags:
     - intranetcms-stg-runner
-  image: dtzar/helm-kubectl
-  script:
-    - kubectl config use-context intranet-cms/cms-k8s-stg-resources:intranetcms-stage-k8s-agent
-    - apk add gettext
-    - envsubst < k8s/intranetcms-stage.yml | kubectl apply -f - -n cms-45-stage
+  variables:
+    KUBE_CONTEXT: intranet-cms/cms-k8s-stg-resources:intranetcms-stage-k8s-agent
+    MANIFEST: k8s/intranetcms-stage.yml
+    NAMESPACE: cms-45-stage
   environment:
     name: stage
-    url:
     kubernetes:
       namespace: cms-45-stage
 
 
 
-Post Deploy:
-  stage: Non-Production Stage Post Deploy
+.postdeploy:
+  stage: post-deploy
+  image: dtzar/helm-kubectl
+  script:
+    - kubectl config use-context $KUBE_CONTEXT
+    - apk add gettext
+    - envsubst < $MANIFEST | kubectl create -f - -n $NAMESPACE
+
+postdeploy:stage:
+  extends: .postdeploy
+  needs:
+    - "deploy:stage"
   rules:
     - if: '$CI_COMMIT_BRANCH == "stage-container-1"'
   tags:
     - intranetcms-stg-runner
-  image: dtzar/helm-kubectl
-  script:
-    - kubectl config use-context intranet-cms/cms-k8s-stg-resources:intranetcms-stage-k8s-agent
-    - apk add gettext
-    - envsubst < k8s/drush.yml | kubectl create -f - -n cms-45-stage
+  variables:
+    KUBE_CONTEXT: intranet-cms/cms-k8s-stg-resources:intranetcms-stage-k8s-agent
+    MANIFEST: k8s/drush.yml
+    NAMESPACE: cms-45-stage
   environment:
     name: stage
-    url:
     kubernetes:
       namespace: cms-45-stage
 
-Post Deploy Dev:  
-  stage: Non-Production Dev Post Deploy
+postdeploy:dev:
+  extends: .postdeploy
+  needs:
+    - "deploy:dev"
   rules:
     - if: '$CI_COMMIT_BRANCH == "dev-container"'
   tags:
     - intranetcms-dev-runner
-  image: dtzar/helm-kubectl
-  script:
-    - kubectl config use-context intranet-cms/intracms-infra-dev:intranetcms-dev-k8s-agent
-    - apk add gettext
-    - envsubst < k8s/drush.yml | kubectl create -f - -n cms-45-dev
+  variables:
+    KUBE_CONTEXT: intranet-cms/intracms-infra-dev:intranetcms-dev-k8s-agent
+    MANIFEST: k8s/drush.yml
+    NAMESPACE: cms-45-dev
   environment:
     name: dev
-    url:
     kubernetes:
       namespace: cms-45-dev
 
-Post Deploy Dev10:
-  stage: Non-Production Dev10 Post Deploy
+postdeploy:dev10:
+  extends: .postdeploy
+  needs:
+    - "deploy:dev10"
   rules:
     - if: '$CI_COMMIT_BRANCH == "dev-container-10"'
   tags:
     - intranetcms-dev-runner
-  image: dtzar/helm-kubectl
-  script:
-    - kubectl config use-context intranet-cms/intracms-infra-dev:intranetcms-dev-k8s-agent
-    - apk add gettext
-    - envsubst < k8s/drush-dev10.yml | kubectl create -f - -n cms-45-next
+  variables:
+    KUBE_CONTEXT: intranet-cms/intracms-infra-dev:intranetcms-dev-k8s-agent
+    MANIFEST: k8s/drush-dev10.yml
+    NAMESPACE: cms-45-next
   environment:
     name: dev10
-    url:
     kubernetes:
       namespace: cms-45-next
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -290,9 +290,11 @@ deploy:prod:
   tags:
     - intranetcms-prod-runner
   variables:
-    # TODO: confirm the prod agent's registered context name (GitLab > Operate >
-    # Kubernetes) and that the agent authorizes the IntraCMS project.
-    KUBE_CONTEXT: intranet-cms/intranetcms-k8s-resources:intranetcms-prod-k8s-agent
+    # The prod resources repo lives in the `production/intranetcms-production`
+    # GitLab group (not `intranet-cms/` like dev/stage). TODO: confirm the agent's
+    # registered name segment (GitLab > Operate > Kubernetes) and that the agent
+    # authorizes the IntraCMS project.
+    KUBE_CONTEXT: production/intranetcms-production/intranetcms-k8s-resources:intranetcms-prod-k8s-agent
     MANIFEST: k8s/intranetcms-prod.yml
     NAMESPACE: cms-45-prod
   environment:
@@ -312,7 +314,8 @@ postdeploy:prod:
   tags:
     - intranetcms-prod-runner
   variables:
-    KUBE_CONTEXT: intranet-cms/intranetcms-k8s-resources:intranetcms-prod-k8s-agent
+    # See deploy:prod for the context-path / agent-name confirmation note.
+    KUBE_CONTEXT: production/intranetcms-production/intranetcms-k8s-resources:intranetcms-prod-k8s-agent
     MANIFEST: k8s/drush.yml
     NAMESPACE: cms-45-prod
   environment:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -337,6 +337,7 @@ The application deploys across multiple environments:
 - **dev** - Development environment
 - **dev10** - Drupal 10 testing environment  
 - **stage** - Staging environment
+- **prod** - Production environment (`cms-45-prod`, host `prod.intranetcms-prod.aws.epa.gov`), released by manual promotion from the stage pipeline
 
 ### Key Kubernetes Resources
 ```yaml
@@ -392,9 +393,22 @@ as soon as the image is built rather than waiting for the security scan:
    the manifests to the environment's namespace
 4. **post-deploy** (`postdeploy:dev` / `postdeploy:dev10` / `postdeploy:stage`) -
    run the verified Drush Job (see Post-Deployment Tasks)
-5. **dast** - Dynamic Application Security Testing (ZAP), manual
+5. **prod-deploy** (`deploy:prod`) - manual promotion of the stage-validated
+   image to production (see Production Promotion below)
+6. **prod-post-deploy** (`postdeploy:prod`) - run the verified Drush Job in prod
+7. **dast** - Dynamic Application Security Testing (ZAP), manual
 
 Each branch runs only the jobs whose `rules:` match it (see Branch Strategy).
+
+### Production Promotion
+Production uses an **image-promotion** model rather than a prod branch. `deploy:prod`
+is a manual job that `needs: postdeploy:stage`, so it only becomes available after
+stage (including its Drush Job) fully succeeds. When played, it deploys the exact
+same `intranetcms-build:<sha>` image that stage validated into the `cms-45-prod`
+namespace via the production GitLab agent, then `postdeploy:prod` runs the same
+verified Drush Job. Because the artifact and Drush steps are identical to stage and
+only environment config differs, a green stage is a strong predictor of prod.
+After stage passes, the pipeline shows "blocked" - that is the ready-to-promote state.
 
 ### Branch Strategy
 - `dev-container` → Development deployment

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,38 +10,35 @@ This is the EPA IntracMS repository - a Drupal 10 intranet site based on the U.S
 
 ## Related Repositories
 
-**This application repository works in tandem with the intranet-cms-infra infrastructure repository.**
+The IntraCMS platform spans several GitLab-side repositories: this repo builds
+and deploys the Drupal application, while other repos provision the AWS/EKS
+infrastructure and the per-environment Kubernetes resources it runs on.
 
 ### Repository Relationship
 
+```mermaid
+flowchart TD
+    INFRA["intranet-cms-infra<br/>Terraform: dev/stage EKS clusters,<br/>namespaces, EFS, Memcached, S3/IRSA,<br/>GitLab agents + builds the PHP base image"]
+    APP["IntraCMS (THIS REPO)<br/>Drupal 10 app, docker/Dockerfile,<br/>k8s/ manifests, .gitlab-ci.yml"]
+    PROD["intranetcms-k8s-resources<br/>Terraform: prod namespace, Fargate profile,<br/>EFS, Memcached, GitLab agent"]
+    K8S["EKS / Fargate<br/>cms-45-dev / cms-45-next / cms-45-stage / prod"]
+    INFRA -->|"intracms-php base image"| APP
+    APP -->|"intranetcms-build image"| K8S
+    INFRA -.->|"provisions dev/stage"| K8S
+    PROD -.->|"provisions prod"| K8S
 ```
-┌─────────────────────────────────┐
-│   intranet-cms-infra          │
-│   Infrastructure as Code        │
-│                                 │
-│   • Creates EKS clusters        │
-│   • Provisions namespaces       │
-│   • Manages AWS resources       │
-│   • Builds PHP base image       │
-└────────────┬────────────────────┘
-             │ Provides infrastructure
-             ↓
-┌─────────────────────────────────┐
-│   IntraCMS (THIS)               │
-│   Application Code              │
-│                                 │
-│   • Drupal 10 application       │
-│   • Deploys to namespaces       │
-│   • Uses S3/EFS resources       │
-│   • Builds app container        │
-└─────────────────────────────────┘
-```
+
+**Repositories at a glance:**
+- **IntraCMS** (this repo; GitHub source mirrored to GitLab `intranet-cms/intracms`) - Drupal 10 application, container build (`docker/Dockerfile`), Kubernetes manifests (`k8s/`), and CI/CD pipeline (`.gitlab-ci.yml`).
+- **intranet-cms-infra** - Terraform for shared dev/stage EKS infrastructure (clusters, the `cms-45-dev`/`cms-45-next`/`cms-45-stage` namespaces, EFS, ElastiCache Memcached, S3 + IRSA, GitLab Kubernetes agents) and the build of the shared PHP 8.3 base image (`intracms-php`).
+- **intranetcms-k8s-resources** - Terraform for the production environment: namespace, Fargate profile, EFS volume, Memcached cluster, and the production GitLab agent (runner tag `intranetcms-prod-runner`).
+- **intracms-infra-dev** and **cms-k8s-stg-resources** (GitLab projects) - host the GitLab Kubernetes agents the pipeline targets for dev/dev10 and stage respectively (see Integration Points below).
 
 ### Infrastructure Repository (intranet-cms-infra)
 **Location**: `~/Repositories/intranet-cms-infra`
 
 **What it provides**:
-- EKS clusters: `cms-shared-dev00` (dev/dev10) and `cms-shared-dev01` (stage)
+- EKS cluster `cms-shared-dev00` (primary; hosts the `cms-45-dev` and `cms-45-next` namespaces); a secondary `cms-shared-dev01` cluster is defined in Terraform but currently disabled
 - Kubernetes namespaces: `cms-45-dev`, `cms-45-next`, `cms-45-stage`
 - AWS S3 bucket: `intranet-cms-dev` with IAM roles for pod access (IRSA)
 - EFS file systems with access points for Drupal files
@@ -60,6 +57,17 @@ This is the EPA IntracMS repository - a Drupal 10 intranet site based on the U.S
 - Container build configuration in `docker/` directory
 - Configuration management in `config/` directory
 
+### Production Resources Repository (intranetcms-k8s-resources)
+**Location**: `~/Repositories/intranetcms-k8s-resources`
+
+**What it provides** (Terraform, applied on its own `main` branch via the `intranetcms-prod-runner`):
+- The production Kubernetes namespace and its Fargate profile (`cms-45-prd-ns`)
+- A production EFS file system and `ReadWriteMany` PersistentVolume/PVC for Drupal's `/public` data
+- A production ElastiCache Memcached cluster (`intranetcms-prod`), with endpoints optionally published to SSM
+- The production GitLab Kubernetes agent used to deploy into the prod namespace
+
+Note: production is provisioned here but is not deployed by this repo's pipeline (which targets dev/dev10/stage only). Production application rollout is handled separately.
+
 ### Integration Points
 
 1. **Deployment Targets**:
@@ -69,9 +77,10 @@ This is the EPA IntracMS repository - a Drupal 10 intranet site based on the U.S
    - `stage-container-1` branch → `cms-45-stage` namespace
 
 2. **GitLab Agents**:
-   - CI/CD uses agents deployed by infrastructure repo
+   - CI/CD selects a GitLab-managed Kubernetes agent per environment (agents are registered by the infra/resources projects, not this repo)
    - Dev/Dev10: `kubectl config use-context intranet-cms/intracms-infra-dev:intranetcms-dev-k8s-agent`
    - Stage: `kubectl config use-context intranet-cms/cms-k8s-stg-resources:intranetcms-stage-k8s-agent`
+   - Prod (managed outside this pipeline): agent registered by `intranetcms-k8s-resources`
 
 3. **Container Images**:
    - Infrastructure provides: `registry.epa.gov/intranet-cms/intracms-infra/intracms-php` (PHP base)
@@ -83,9 +92,9 @@ This is the EPA IntracMS repository - a Drupal 10 intranet site based on the U.S
    - Mount point: `/public` for Drupal public files
 
 5. **Caching**:
-   - Memcached endpoints provisioned by infrastructure repo
-   - Retrieved from AWS SSM Parameter Store: `/intranetcms/dev/endpoints/memcached`
-   - Configure in Drupal's `settings.php` for Memcache module
+   - Memcached clusters are provisioned by the infra repos (dev/stage in `intranet-cms-infra`, prod in `intranetcms-k8s-resources`)
+   - Endpoints are published to AWS SSM Parameter Store: dev under `/intranetcms/dev/endpoints/memcached`, prod under `/echs/intranetcms/prod/endpoints/memcached`
+   - The Memcache module is configured in Drupal's `settings.php`/`settings.local.php`, which are mounted at runtime from the EFS `/public` volume (see the Dockerfile symlinks) rather than baked into the image
 
 6. **Networking**:
    - NGINX ingress controllers provisioned by infrastructure
@@ -109,6 +118,10 @@ This is the EPA IntracMS repository - a Drupal 10 intranet site based on the U.S
 - Modifying deployment replicas or resource requests
 - Updating application environment variables
 - Working on Drupal features, content, or design
+
+**Work in intranetcms-k8s-resources when**:
+- Changing the production namespace, Fargate profile, EFS, or Memcached
+- Rotating or reconfiguring the production GitLab Kubernetes agent
 
 ## Development Environment Setup
 
@@ -299,12 +312,25 @@ The system applies numerous patches for Drupal 10 compatibility and enhanced fun
 ## Container Deployment & Kubernetes
 
 ### Image Build Process
+The `build:image` job builds the app image with Kaniko and pushes it as
+`intranetcms-build:<short-sha>`. Layer caching is enabled so unchanged layers -
+in particular the Composer dependency layer - are restored from a registry cache
+instead of rebuilt. The Dockerfile copies `composer.json`/`composer.lock` and
+`patches/` and runs `composer install` *before* copying the rest of the source,
+so that dependency layer only rebuilds when dependencies actually change.
 ```bash
-# GitLab CI builds images using Kaniko
-/kaniko/executor --context $CI_PROJECT_DIR \
+/kaniko/executor \
+  --context $CI_PROJECT_DIR \
   --dockerfile $CI_PROJECT_DIR/docker/Dockerfile \
+  --build-arg PHP_BASE_TAG=${PHP_BASE_TAG:-latest} \
+  --cache=true \
+  --cache-repo=$CI_REGISTRY_IMAGE/cache \
+  --cache-ttl=336h \
+  --cache-copy-layers=true \
   --destination $CI_REGISTRY_IMAGE/intranetcms-build:$CI_COMMIT_SHORT_SHA
 ```
+The base PHP image tag is controlled by the `PHP_BASE_TAG` build arg (default
+`latest`); set a `PHP_BASE_TAG` CI/CD variable to pin an immutable base image.
 
 ### Kubernetes Deployment
 The application deploys across multiple environments:
@@ -336,20 +362,39 @@ kubectl exec -it deployment/intranetcms -n cms-45-dev -- drush status
 ```
 
 ### Post-Deployment Tasks
-Automated via Kubernetes jobs:
+Post-deploy Drush runs as a Kubernetes **Job** (`k8s/drush.yml`, `k8s/drush-dev10.yml`),
+launched by the `postdeploy:<env>` CI job. The CI job waits for the Job to finish,
+streams its logs, and fails the pipeline if Drush fails or times out (the Job has
+`backoffLimit: 0` and `activeDeadlineSeconds: 1800`).
+
+The Job wraps the update in a fail-closed maintenance window: it enables
+maintenance mode, runs the updates, then lifts maintenance only if every step
+succeeded. If any step fails, the site stays in maintenance and the pipeline fails.
 ```bash
-# Database updates, cache clear, config import
-drush @intra updb --yes && drush @intra cr && drush @intra cim --yes
+# Enable maintenance mode (bootstrap-free), then update, then lift it:
+drush @intra sql:query "REPLACE INTO key_value (collection, name, value) VALUES ('state', 'system.maintenance_mode', 'b:1;')" \
+  && drush @intra updb --yes \
+  && drush @intra cim --yes \
+  && drush @intra cr \
+  && drush @intra sql:query "DELETE FROM key_value WHERE collection = 'state' AND name = 'system.maintenance_mode'"
 ```
 
 ## GitLab CI/CD Pipeline
 
 ### Pipeline Stages
-1. **build** - Container image creation with Kaniko
-2. **prisma scan** - Security vulnerability scanning
-3. **Non-Production Deployments** - Dev, Stage, Dev10 environments
-4. **Post Deploy** - Drush commands for database updates
-5. **dast** - Dynamic Application Security Testing (manual)
+The pipeline uses a `needs:` DAG (not strict stage ordering), so a deploy starts
+as soon as the image is built rather than waiting for the security scan:
+
+1. **build** (`build:image`) - build + push the app image with Kaniko (cached)
+2. **scan** (`Prisma Scan`) - Prisma Cloud image scan; runs in parallel with the
+   deploy and is non-blocking (`allow_failure: true`)
+3. **deploy** (`deploy:dev` / `deploy:dev10` / `deploy:stage`) - `kubectl apply`
+   the manifests to the environment's namespace
+4. **post-deploy** (`postdeploy:dev` / `postdeploy:dev10` / `postdeploy:stage`) -
+   run the verified Drush Job (see Post-Deployment Tasks)
+5. **dast** - Dynamic Application Security Testing (ZAP), manual
+
+Each branch runs only the jobs whose `rules:` match it (see Branch Strategy).
 
 ### Branch Strategy
 - `dev-container` → Development deployment

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,21 +30,19 @@ flowchart TD
 
 **Repositories at a glance:**
 - **IntraCMS** (this repo; GitHub source mirrored to GitLab `intranet-cms/intracms`) - Drupal 10 application, container build (`docker/Dockerfile`), Kubernetes manifests (`k8s/`), and CI/CD pipeline (`.gitlab-ci.yml`).
-- **intranet-cms-infra** - Terraform for shared dev/stage EKS infrastructure (clusters, the `cms-45-dev`/`cms-45-next`/`cms-45-stage` namespaces, EFS, ElastiCache Memcached, S3 + IRSA, GitLab Kubernetes agents) and the build of the shared PHP 8.3 base image (`intracms-php`).
+- **intranet-cms-infra** - Terraform for the shared non-prod EKS cluster(s), the S3 bucket + IRSA, and the build of the shared PHP 8.3 base image (`intracms-php`).
 - **intranetcms-k8s-resources** - Terraform for the production environment: namespace, Fargate profile, EFS volume, Memcached cluster, and the production GitLab agent (runner tag `intranetcms-prod-runner`).
-- **intracms-infra-dev** and **cms-k8s-stg-resources** (GitLab projects) - host the GitLab Kubernetes agents the pipeline targets for dev/dev10 and stage respectively (see Integration Points below).
+- **intracms-infra-dev** (dev/dev10) and **cms-k8s-stg-resources** (stage) - per-environment Terraform that provisions each environment's namespace, EFS/PVC, Memcached, and GitLab agent; the pipeline deploys through those agents (see Integration Points below).
 
 ### Infrastructure Repository (intranet-cms-infra)
 **Location**: `~/Repositories/intranet-cms-infra`
 
 **What it provides**:
-- EKS cluster `cms-shared-dev00` (primary; hosts the `cms-45-dev` and `cms-45-next` namespaces); a secondary `cms-shared-dev01` cluster is defined in Terraform but currently disabled
-- Kubernetes namespaces: `cms-45-dev`, `cms-45-next`, `cms-45-stage`
-- AWS S3 bucket: `intranet-cms-dev` with IAM roles for pod access (IRSA)
-- EFS file systems with access points for Drupal files
-- ElastiCache Memcached cluster for Drupal caching
-- GitLab Kubernetes agents for CI/CD deployment
-- PHP 8.3 base container image with NGINX
+- Shared EKS cluster(s) for the non-prod environments
+- The PHP 8.3 + NGINX base container image (`intracms-php`) that the app image is built `FROM`
+- AWS S3 bucket `intranet-cms-dev` with IAM roles for pod access (IRSA)
+
+Note: the per-environment Kubernetes namespaces, EFS volumes/PVCs, Memcached clusters, and GitLab agents are each provisioned by the per-environment resources repos - `intracms-infra-dev` (dev/dev10), `cms-k8s-stg-resources` (stage), and `intranetcms-k8s-resources` (prod) - not by this repo.
 
 ### Application Repository (IntraCMS)
 **Location**: `~/Repositories/IntraCMS` (THIS REPOSITORY)
@@ -409,6 +407,13 @@ namespace via the production GitLab agent, then `postdeploy:prod` runs the same
 verified Drush Job. Because the artifact and Drush steps are identical to stage and
 only environment config differs, a green stage is a strong predictor of prod.
 After stage passes, the pipeline shows "blocked" - that is the ready-to-promote state.
+
+**Prerequisites:** the production resources must already be applied from the
+`intranetcms-k8s-resources` repo (namespace `cms-45-prod`, the EFS PVC, the
+`glcr-auth` pull secret, and the production GitLab agent) before a promotion can
+succeed. The TLS secret `tls-devsecops-shared-webapp` is provided by the platform
+(DSO), not by these repos' Terraform, so it must already exist in `cms-45-prod`
+with a certificate covering `prod.intranetcms-prod.aws.epa.gov`.
 
 ### Branch Strategy
 - `dev-container` → Development deployment

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,19 @@
-FROM registry.epa.gov/intranet-cms/intranet-cms-infra/intracms-php:latest
+ARG PHP_BASE_TAG=latest
+FROM registry.epa.gov/intranet-cms/intranet-cms-infra/intracms-php:${PHP_BASE_TAG}
 SHELL ["/bin/bash", "-c"]
 
-WORKDIR /app 
+WORKDIR /app
 
+# Dependency layer: copy only the Composer manifests and local patches first so
+# this expensive step (package downloads + patch fetches) is cached by Kaniko
+# across commits that do not change dependencies.
+COPY composer.json composer.lock ./
+COPY patches/ ./patches/
+RUN composer install --no-interaction --no-progress --prefer-dist --optimize-autoloader --no-dev
+
+# Application layer: bring in the rest of the source on top of the installed deps.
 COPY . .
 
-RUN composer clearcache
-RUN composer install --no-interaction
 RUN ./docker/scripts/bower.sh
 RUN rsync -avz --recursive --links --times --executability --delete --delete-after --exclude=docker --exclude=k8s --exclude=*web.config --exclude=docroot/sites/*/settings.php --exclude=docroot/sites/*/settings.local.php --exclude=docroot/sites/*/services.yml --exclude=docroot/tools --exclude=docroot/sites/*/files --exclude=vendor/simplesamlphp/simplesamlphp/config --exclude=vendor/simplesamlphp/simplesamlphp/metadata --exclude=vendor/simplesamlphp/simplesamlphp/cert --delay-updates * /srv/drupal-root
 RUN ln -s /srv/drupal-root/vendor/drush/drush/drush /usr/bin/drush 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,6 @@
+# Base image is the PHP 8.3 + NGINX image built by the intranet-cms-infra repo.
+# PHP_BASE_TAG lets CI pin an immutable tag (see .gitlab-ci.yml --build-arg);
+# it defaults to 'latest' so local/manual builds keep working.
 ARG PHP_BASE_TAG=latest
 FROM registry.epa.gov/intranet-cms/intranet-cms-infra/intracms-php:${PHP_BASE_TAG}
 SHELL ["/bin/bash", "-c"]
@@ -9,13 +12,22 @@ WORKDIR /app
 # across commits that do not change dependencies.
 COPY composer.json composer.lock ./
 COPY patches/ ./patches/
+# --prefer-dist avoids slow git clones; --optimize-autoloader speeds runtime
+# class loading; --no-dev drops dev-only deps (drush/devel live in `require`, so
+# they remain); --no-progress keeps the build log readable.
 RUN composer install --no-interaction --no-progress --prefer-dist --optimize-autoloader --no-dev
 
 # Application layer: bring in the rest of the source on top of the installed deps.
 COPY . .
 
+# Copy bower-managed front-end libraries into docroot/libraries.
 RUN ./docker/scripts/bower.sh
+# Publish the built app to /srv/drupal-root, excluding env-specific and secret
+# files (settings*.php, services.yml, SimpleSAMLphp config/metadata/cert) that
+# are supplied at runtime from the EFS-mounted /public volume, not baked in.
 RUN rsync -avz --recursive --links --times --executability --delete --delete-after --exclude=docker --exclude=k8s --exclude=*web.config --exclude=docroot/sites/*/settings.php --exclude=docroot/sites/*/settings.local.php --exclude=docroot/sites/*/services.yml --exclude=docroot/tools --exclude=docroot/sites/*/files --exclude=vendor/simplesamlphp/simplesamlphp/config --exclude=vendor/simplesamlphp/simplesamlphp/metadata --exclude=vendor/simplesamlphp/simplesamlphp/cert --delay-updates * /srv/drupal-root
+# Symlink runtime config/data (drush alias+binary, files, settings, SimpleSAMLphp)
+# from the EFS-mounted /public volume into the Drupal root.
 RUN ln -s /srv/drupal-root/vendor/drush/drush/drush /usr/bin/drush 
 RUN ln -s /public/data/drupal-files /srv/drupal-root/docroot/sites/default/files 
 RUN ln -s /public/server/maint/default/settings.php /srv/drupal-root/docroot/sites/default/settings.php 
@@ -27,6 +39,7 @@ RUN ln -s /srv/drupal-root/vendor/simplesamlphp/simplesamlphp/public /srv/drupal
 RUN ln -s /public/server/maint/drush-files/intra/ /srv/drupal-root/drush
 RUN ln -s /srv/drupal-root/vendor/drush/drush/drush.php /usr/bin/drush.php
 
+# Drop the build context now that the app has been published to /srv/drupal-root.
 RUN rm -rf /app/*
 
 ENTRYPOINT ["/etc/entrypoint.sh"]

--- a/k8s/drush-dev10.yml
+++ b/k8s/drush-dev10.yml
@@ -1,29 +1,44 @@
-apiVersion: v1
-kind: Pod
+apiVersion: batch/v1
+kind: Job
 metadata:
   generateName: drush-
   labels:
     purpose: clear-drupal-cache
 spec:
-  volumes:
-  - name: intranetcms-next-storage
-    persistentVolumeClaim:
-      claimName: intranetcms-next-efs-pvc
-  containers:
-  - name: intranetcms
-    image: registry.epa.gov/intranet-cms/intracms/intranetcms-build:$CI_COMMIT_SHORT_SHA
-    resources:
-      requests:
-        memory: "1G"
-        cpu: ".5"
-      limits:
-        memory: "2G"
-        cpu: "1"
-    command: ["/bin/sh"]
-    args: ["-c", "/srv/drupal-root/vendor/drush/drush/drush @intra updb --yes && /srv/drupal-root/vendor/drush/drush/drush @intra cr && /srv/drupal-root/vendor/drush/drush/drush @intra cim --yes"]
-    volumeMounts:
-    - name: intranetcms-next-storage
-      mountPath: /public
-  imagePullSecrets:
-    - name: glcr-auth
-  restartPolicy: Never
+  # Fail fast (no retries) and cap the run so a stuck deploy step cannot hang.
+  backoffLimit: 0
+  activeDeadlineSeconds: 1800
+  template:
+    metadata:
+      labels:
+        purpose: clear-drupal-cache
+    spec:
+      volumes:
+      - name: intranetcms-next-storage
+        persistentVolumeClaim:
+          claimName: intranetcms-next-efs-pvc
+      containers:
+      - name: intranetcms
+        image: registry.epa.gov/intranet-cms/intracms/intranetcms-build:$CI_COMMIT_SHORT_SHA
+        resources:
+          requests:
+            memory: "1G"
+            cpu: ".5"
+          limits:
+            memory: "2G"
+            cpu: "1"
+        command: ["/bin/sh"]
+        args:
+          - "-c"
+          - >-
+            /srv/drupal-root/vendor/drush/drush/drush @intra sql:query "REPLACE INTO key_value (collection, name, value) VALUES ('state', 'system.maintenance_mode', 'b:1;')"
+            && /srv/drupal-root/vendor/drush/drush/drush @intra updb --yes
+            && /srv/drupal-root/vendor/drush/drush/drush @intra cim --yes
+            && /srv/drupal-root/vendor/drush/drush/drush @intra cr
+            && /srv/drupal-root/vendor/drush/drush/drush @intra sql:query "DELETE FROM key_value WHERE collection = 'state' AND name = 'system.maintenance_mode'"
+        volumeMounts:
+        - name: intranetcms-next-storage
+          mountPath: /public
+      imagePullSecrets:
+        - name: glcr-auth
+      restartPolicy: Never

--- a/k8s/drush-dev10.yml
+++ b/k8s/drush-dev10.yml
@@ -1,3 +1,7 @@
+# Post-deploy Drush Job for IntraCMS dev10 (namespace cms-45-next). Launched by
+# the .postdeploy CI job after a successful deploy; CI waits for it and fails the
+# pipeline if it does not succeed. Uses a Job (not a bare Pod) so it exposes real
+# succeeded/failed status to poll.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -28,6 +32,17 @@ spec:
             memory: "2G"
             cpu: "1"
         command: ["/bin/sh"]
+        # Post-deploy Drush wrapped in a maintenance window (fail-closed):
+        #   1) enable maintenance mode via raw SQL - no Drupal bootstrap needed,
+        #      safe even if new-code + old-schema would break a full bootstrap
+        #   2) updb : apply pending database updates
+        #   3) cim  : import configuration
+        #   4) cr   : rebuild caches
+        #   5) disable maintenance mode (only reached if every step above passed)
+        # The `&&` chain means any failure leaves the site IN maintenance and the
+        # Job exits non-zero (surfaced by the CI .postdeploy wait).
+        # NOTE: assumes no DB table prefix; `drush sql:query` does not apply
+        # Drupal's table prefix, so adjust `key_value` if a prefix is configured.
         args:
           - "-c"
           - >-

--- a/k8s/drush.yml
+++ b/k8s/drush.yml
@@ -1,3 +1,7 @@
+# Post-deploy Drush Job for IntraCMS (dev and stage namespaces). Launched by the
+# .postdeploy CI job after a successful deploy; CI waits for it and fails the
+# pipeline if it does not succeed. Uses a Job (not a bare Pod) so it exposes real
+# succeeded/failed status to poll.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -28,6 +32,17 @@ spec:
             memory: "2G"
             cpu: "1"
         command: ["/bin/sh"]
+        # Post-deploy Drush wrapped in a maintenance window (fail-closed):
+        #   1) enable maintenance mode via raw SQL - no Drupal bootstrap needed,
+        #      safe even if new-code + old-schema would break a full bootstrap
+        #   2) updb : apply pending database updates
+        #   3) cim  : import configuration
+        #   4) cr   : rebuild caches
+        #   5) disable maintenance mode (only reached if every step above passed)
+        # The `&&` chain means any failure leaves the site IN maintenance and the
+        # Job exits non-zero (surfaced by the CI .postdeploy wait).
+        # NOTE: assumes no DB table prefix; `drush sql:query` does not apply
+        # Drupal's table prefix, so adjust `key_value` if a prefix is configured.
         args:
           - "-c"
           - >-

--- a/k8s/drush.yml
+++ b/k8s/drush.yml
@@ -1,29 +1,44 @@
-apiVersion: v1
-kind: Pod
+apiVersion: batch/v1
+kind: Job
 metadata:
   generateName: drush-
   labels:
     purpose: clear-drupal-cache
 spec:
-  volumes:
-  - name: intranetcms-storage
-    persistentVolumeClaim:
-      claimName: intranetcms-efs-pvc
-  containers:
-  - name: intranetcms
-    image: registry.epa.gov/intranet-cms/intracms/intranetcms-build:$CI_COMMIT_SHORT_SHA
-    resources:
-      requests:
-        memory: "1G"
-        cpu: ".5"
-      limits:
-        memory: "2G"
-        cpu: "1"
-    command: ["/bin/sh"]
-    args: ["-c", "/srv/drupal-root/vendor/drush/drush/drush @intra updb --yes && /srv/drupal-root/vendor/drush/drush/drush @intra cr && /srv/drupal-root/vendor/drush/drush/drush @intra cim --yes"]
-    volumeMounts:
-    - name: intranetcms-storage
-      mountPath: /public
-  imagePullSecrets:
-    - name: glcr-auth
-  restartPolicy: Never
+  # Fail fast (no retries) and cap the run so a stuck deploy step cannot hang.
+  backoffLimit: 0
+  activeDeadlineSeconds: 1800
+  template:
+    metadata:
+      labels:
+        purpose: clear-drupal-cache
+    spec:
+      volumes:
+      - name: intranetcms-storage
+        persistentVolumeClaim:
+          claimName: intranetcms-efs-pvc
+      containers:
+      - name: intranetcms
+        image: registry.epa.gov/intranet-cms/intracms/intranetcms-build:$CI_COMMIT_SHORT_SHA
+        resources:
+          requests:
+            memory: "1G"
+            cpu: ".5"
+          limits:
+            memory: "2G"
+            cpu: "1"
+        command: ["/bin/sh"]
+        args:
+          - "-c"
+          - >-
+            /srv/drupal-root/vendor/drush/drush/drush @intra sql:query "REPLACE INTO key_value (collection, name, value) VALUES ('state', 'system.maintenance_mode', 'b:1;')"
+            && /srv/drupal-root/vendor/drush/drush/drush @intra updb --yes
+            && /srv/drupal-root/vendor/drush/drush/drush @intra cim --yes
+            && /srv/drupal-root/vendor/drush/drush/drush @intra cr
+            && /srv/drupal-root/vendor/drush/drush/drush @intra sql:query "DELETE FROM key_value WHERE collection = 'state' AND name = 'system.maintenance_mode'"
+        volumeMounts:
+        - name: intranetcms-storage
+          mountPath: /public
+      imagePullSecrets:
+        - name: glcr-auth
+      restartPolicy: Never

--- a/k8s/intranetcms-dev10.yml
+++ b/k8s/intranetcms-dev10.yml
@@ -61,7 +61,6 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 15
           timeoutSeconds: 20
-          failureThreshold: 2
           failureThreshold: 100
         readinessProbe:
           tcpSocket:

--- a/k8s/intranetcms-prod.yml
+++ b/k8s/intranetcms-prod.yml
@@ -1,0 +1,143 @@
+# Production Deployment/Service/Ingress for IntraCMS (namespace cms-45-prod).
+#
+# This manifest mirrors k8s/intranetcms-stage.yml so that promoting from stage to
+# prod changes only environment config - never the application. It is applied by
+# the manual `deploy:prod` job, which reuses the SAME intranetcms-build:<sha>
+# image that stage already validated (see .gitlab-ci.yml). No rebuild = no drift.
+#
+# Confirm before the first production release:
+#   - PVC name matches what intranetcms-k8s-resources provisions in cms-45-prod
+#     (expected intranetcms-efs-pvc; verify: kubectl get pvc -n cms-45-prod)
+#   - Secret tls-devsecops-shared-webapp exists in cms-45-prod with a certificate
+#     covering prod.intranetcms-prod.aws.epa.gov
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: intranetcms
+  annotations:
+    app.gitlab.com/app: ${CI_PROJECT_PATH_SLUG}
+    app.gitlab.com/env: ${CI_ENVIRONMENT_SLUG}
+    # Schedule pods on AWS Fargate (serverless; no EC2 node group).
+    eks.amazonaws.com/compute-type: fargate
+spec:
+  # Production runs 2 replicas for high availability. With maxUnavailable: 0
+  # below, a rollout always keeps at least one healthy pod serving traffic.
+  replicas: 2
+  selector:
+    matchLabels:
+      app: intranetcms
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: intranetcms
+      annotations:
+        app.gitlab.com/app: ${CI_PROJECT_PATH_SLUG}
+        app.gitlab.com/env: ${CI_ENVIRONMENT_SLUG}
+    spec:
+      # nginx and php-fpm share the pod network; "backend" resolves to localhost.
+      hostAliases:
+        - ip: "127.0.0.1"
+          hostnames:
+            - "backend"
+      volumes:
+        # Shared Drupal data (files, settings, SimpleSAMLphp config) on EFS.
+        - name: intranetcms-storage
+          persistentVolumeClaim:
+            claimName: intranetcms-efs-pvc
+      containers:
+        - name: intranetcms
+          # Promoted image: the exact tag built and validated in stage.
+          image: registry.epa.gov/intranet-cms/intracms/intranetcms-build:$CI_COMMIT_SHORT_SHA
+          imagePullPolicy: Always
+          resources:
+            # Match stage sizing for parity.
+            requests:
+              memory: "8G"
+              cpu: "4"
+            limits:
+              memory: "8G"
+              cpu: "4"
+          ports:
+            - containerPort: 9000
+            - containerPort: 443
+          env:
+            # A changing value forces a fresh rollout on each deploy.
+            - name: REDEPLOY_META
+              value: $CI_JOB_ID-$CI_COMMIT_SHA
+            - name: WEB_HTTPS
+              value: "false"
+            - name: WEB_HTTPS_ONLY
+              value: "false"
+          # TCP probes on 443 (nginx terminates TLS inside the container).
+          livenessProbe:
+            tcpSocket:
+              port: 443
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: 2
+          readinessProbe:
+            tcpSocket:
+              port: 443
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          volumeMounts:
+            - name: intranetcms-storage
+              mountPath: /public
+      imagePullSecrets:
+        - name: glcr-auth
+
+---
+
+# Service exposes the pods' HTTPS port inside the cluster for the Ingress.
+apiVersion: v1
+kind: Service
+metadata:
+  name: intranetcms
+  annotations:
+    app.gitlab.com/app: ${CI_PROJECT_PATH_SLUG}
+    app.gitlab.com/env: ${CI_ENVIRONMENT_SLUG}
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 443
+      name: https
+  selector:
+    app: intranetcms
+
+---
+
+# Ingress routes the production host to the Service via the nginx controller.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: intranetcms-ingress
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    app.gitlab.com/app: ${CI_PROJECT_PATH_SLUG}
+    app.gitlab.com/env: ${CI_ENVIRONMENT_SLUG}
+    nginx.ingress.kubernetes.io/proxy-body-size: 21m
+spec:
+  tls:
+    - hosts:
+        - prod.intranetcms-prod.aws.epa.gov
+      # Secret must be provisioned by DSO in cms-45-prod and cover the host above.
+      # (The public vanity URL intranet.epa.gov is terminated by an upstream
+      # front-door and forwarded to this AWS origin host.)
+      secretName: tls-devsecops-shared-webapp
+  rules:
+    - host: prod.intranetcms-prod.aws.epa.gov
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: intranetcms
+                port:
+                  number: 443


### PR DESCRIPTION
This update refines the CI/CD pipeline and adds supporting documentation, aiming to enhance deployment reliability and efficiency.

Improvements:
- **Robust post-deployment:** Migrates Drush update commands from bare Kubernetes Pods to verifiable Kubernetes Jobs. The pipeline now explicitly waits for these Jobs to complete, providing real-time status and failing the build if Drush operations (updates, config imports, cache clears) encounter errors or time out. Drush operations are also safely wrapped in maintenance mode to prevent broken states.
- **Efficient image builds:** Implements Kaniko layer caching for the Docker build process, drastically reducing build times for unchanged dependencies. It also introduces `PHP_BASE_TAG` for flexible base image pinning.
- **Streamlined CI/CD stages:** Refactors and standardizes job and stage naming, creating a clearer and more consistent pipeline flow. It introduces reusable GitLab CI templates for deploy and post-deploy jobs, reducing redundancy across environments.
- **Pipeline optimization:** Utilizes a Directed Acyclic Graph (DAG) with explicit `needs:` dependencies, allowing the Prisma Cloud security scan to run in parallel with the deployment jobs, without blocking the overall deployment progress.
- **Enhanced documentation:** Updates the architecture and deployment guide (`ARCHITECTURE.md`) with a clearer repository overview, a Mermaid flowchart, and detailed explanations of the improved build and deployment processes.
- **Kubernetes stability:** Adjusts liveness probe `failureThreshold` for dev10 deployments to improve application stability during startup.